### PR TITLE
Más facilidad de instalación y documentación

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.save
+VigasocoSDL/VigasocoSDL
+VigasocoSDL/audio/
+VigasocoSDL/input/
+VigasocoSDL/video/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,25 @@
-all:
-	cd SDLInputKeyboardPlugin && make
-	cd FakeInputPlugin && make
-	cd SDLVideoPlugins && make
-	cd SDLAudioPlugin && make
-	cd NULLAudioPlugin && make
-	cd VigasocoSDL && make
+.PHONY: all folders build run clean
+
+MAKEOPTIONS = CXX=clang LD=clang
+
+all: folders build
+
+folders:
+	mkdir -p VigasocoSDL/audio
+	mkdir -p VigasocoSDL/video
+	mkdir -p VigasocoSDL/input
+
+build:
+	cd SDLInputKeyboardPlugin && $(MAKEOPTIONS) make
+	cd FakeInputPlugin && $(MAKEOPTIONS) make
+	cd SDLVideoPlugins && make && $(MAKEOPTIONS) make
+	cd SDLAudioPlugin && $(MAKEOPTIONS) make
+	cd NULLAudioPlugin && $(MAKEOPTIONS) make
+	cd VigasocoSDL && $(MAKEOPTIONS) make
+
+
+run:
+	cd VigasocoSDL && ./VigasocoSDL abadia -audio:libVigasocoNULLAudioPlugin.so,NULLAudioPlugin -input:libVigasocoFakeInputPlugin.so,FakeInputPlugin -input:libVigasocoSDLInputPlugin.so,SDLInputPlugin
 
 clean:
 	cd SDLInputKeyboardPlugin && make clean

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# VigasocoSDL AbadIA version
+
+A branch of VigasocoSDL to allow interaction with the AbadIA project through a REST server.
+
+## Install instructions
+
+### Prerequisites
+
+Create the resources folders
+
+```bash
+mkdir VigasocoSDL/audio
+mkdir VigasocoSDL/video
+mkdir VigasocoSDL/input
+```
+
+Make sure your system includes clang, libboost and sdl1.2 . You can install these through
+
+```bash
+sudo apt-get install clang libboost-all-dev libsdl1.2-dev
+```
+
+or the equivalent package manager for your Linux distribution.
+
+### Compilation
+
+Compile the project with
+
+```bash
+CXX=clang LD=clang make
+```
+
+## Usage
+
+To launch VigasocoSDL running "La Abadía del Crimen", type
+
+```bash
+./VigasocoSDL abadia -audio:libVigasocoNULLAudioPlugin.so,NULLAudioPlugin -input:libVigasocoFakeInputPlugin.so,FakeInputPlugin -input:libVigasocoSDLInputPlugin.so,SDLInputPlugin
+```

--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@ A branch of VigasocoSDL to allow interaction with the AbadIA project through a R
 
 ### Prerequisites
 
-Create the resources folders
-
-```bash
-mkdir VigasocoSDL/audio
-mkdir VigasocoSDL/video
-mkdir VigasocoSDL/input
-```
-
 Make sure your system includes clang, libboost and sdl1.2 . You can install these through
 
 ```bash
@@ -27,7 +19,7 @@ or the equivalent package manager for your Linux distribution.
 Compile the project with
 
 ```bash
-CXX=clang LD=clang make
+make
 ```
 
 ## Usage
@@ -35,5 +27,5 @@ CXX=clang LD=clang make
 To launch VigasocoSDL running "La Abadía del Crimen", type
 
 ```bash
-./VigasocoSDL abadia -audio:libVigasocoNULLAudioPlugin.so,NULLAudioPlugin -input:libVigasocoFakeInputPlugin.so,FakeInputPlugin -input:libVigasocoSDLInputPlugin.so,SDLInputPlugin
+make run
 ```


### PR DESCRIPTION
Modificado el Makefile para que se encargue de:

* Crear las carpetas necesarias para la compilación
* En la compilación, llamar al make de cada subcarpeta con las opciones correctas de clang.
* Facilitar la ejecución de VigasocoSDL en el modo adecuado para abadIA

Se incluye también un README.md para facilitar el uso.