### PR TITLE
Migración de SDL 1.2 a SDL2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ audio-plugins-dir := VigasocoSDL/audio
 video-plugins-dir := VigasocoSDL/video
 
 all: | $(input-plugins-dir) $(audio-plugins-dir) $(video-plugins-dir)
-	cd SDLInputKeyboardPlugin && make
-	cd SDLVideoPlugins && make
-	cd SDLAudioPlugin && make
-	cd NULLAudioPlugin && make
-	cd VigasocoSDL && make
+	cd SDLInputKeyboardPlugin && $(MAKE)
+	cd SDLVideoPlugins && $(MAKE)
+	cd SDLAudioPlugin && $(MAKE)
+	cd NULLAudioPlugin && $(MAKE)
+	cd VigasocoSDL && $(MAKE)
 
 $(input-plugins-dir):
 	mkdir $(input-plugins-dir)
@@ -19,8 +19,8 @@ $(video-plugins-dir):
 	mkdir $(video-plugins-dir)
 
 clean:
-	cd SDLInputKeyboardPlugin && make clean
-	cd SDLVideoPlugins && make clean
-	cd SDLAudioPlugin && make clean
-	cd NULLAudioPlugin && make clean
-	cd VigasocoSDL && make clean
+	cd SDLInputKeyboardPlugin && $(MAKE) clean
+	cd SDLVideoPlugins && $(MAKE) clean
+	cd SDLAudioPlugin && $(MAKE) clean
+	cd NULLAudioPlugin && $(MAKE) clean
+	cd VigasocoSDL && $(MAKE) clean

--- a/Makefile.static
+++ b/Makefile.static
@@ -1,14 +1,14 @@
 all:
-	cd SDLInputKeyboardPlugin && make -f Makefile.static
-	cd SDLVideoPlugins && make -f Makefile.static
-	cd SDLAudioPlugin && make -f Makefile.static
-	cd NULLAudioPlugin && make -f Makefile.static
-	cd VigasocoSDL && make -f Makefile.static
+	cd SDLInputKeyboardPlugin && $(MAKE) -f Makefile.static
+	cd SDLVideoPlugins && $(MAKE) -f Makefile.static
+	cd SDLAudioPlugin && $(MAKE) -f Makefile.static
+	cd NULLAudioPlugin && $(MAKE) -f Makefile.static
+	cd VigasocoSDL && $(MAKE) -f Makefile.static
 
 clean:
-	cd SDLInputKeyboardPlugin && make -f Makefile.static clean
-	cd SDLVideoPlugins && make -f Makefile.static clean
-	cd SDLAudioPlugin && make -f Makefile.static clean
-	cd NULLAudioPlugin && make -f Makefile.static clean
-	cd VigasocoSDL && make -f Makefile.static clean
+	cd SDLInputKeyboardPlugin && $(MAKE) -f Makefile.static clean
+	cd SDLVideoPlugins && $(MAKE) -f Makefile.static clean
+	cd SDLAudioPlugin && $(MAKE) -f Makefile.static clean
+	cd NULLAudioPlugin && $(MAKE) -f Makefile.static clean
+	cd VigasocoSDL && $(MAKE) -f Makefile.static clean
 	

--- a/NULLAudioPlugin/Makefile.static
+++ b/NULLAudioPlugin/Makefile.static
@@ -6,6 +6,7 @@ VPATH=.:../core:../core/abadia:../core/util:../core/systems
 OBJECTS = NULLAudioPlugin.o PluginMain.o
 
 ../VigasocoSDL/audio/libVigasocoNULLAudioPlugin.a: $(OBJECTS)
+	mkdir -p $(dir $@)
 	$(AR) cru $@ $(OBJECTS)
 
 # para comprobar que no le faltan dependencias por resolver a la libreria

--- a/SDLAudioPlugin/Makefile
+++ b/SDLAudioPlugin/Makefile
@@ -1,5 +1,5 @@
-CXXFLAGS=-O3 -fPIC -I../core -I../VigasocoSDL/ `sdl-config --cflags`
-#CXXFLAGS=-g -fPIC -I../core -I../VigasocoSDL/ `sdl-config --cflags`
+CXXFLAGS=-O3 -fPIC -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
+#CXXFLAGS=-g -fPIC -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
 VPATH=.:../core:../core/abadia:../core/util:../core/systems
 
 OBJECTS = SDLAudioPlugin.o NULLAudioPlugin.o PluginMain.o
@@ -10,7 +10,7 @@ OBJECTS = SDLAudioPlugin.o NULLAudioPlugin.o PluginMain.o
 
 # para comprobar que no le faltan dependencias por resolver a la libreria
 test: test.o
-	$(CXX) -g test.o -o test -L ../VigasocoSDL/audio/ -l VigasocoSDLAudioPlugin `sdl-config --libs`
+	$(CXX) -g test.o -o test -L ../VigasocoSDL/audio/ -l VigasocoSDLAudioPlugin `sdl2-config --libs`
 
 clean:
 	rm -f $(OBJECTS) ../VigasocoSDL/audio/libVigasocoSDLAudioPlugin.so test test.o

--- a/SDLAudioPlugin/Makefile.static
+++ b/SDLAudioPlugin/Makefile.static
@@ -1,16 +1,17 @@
-CXXFLAGS=-D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl-config --cflags`
-#CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl-config --cflags`
-#CXXFLAGS=-Os -D__VIGASOCO_SDL_STATIC__ -I../core -I../VigasocoSDL/ `sdl-config --cflags`
+CXXFLAGS=-D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
+#CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
+#CXXFLAGS=-Os -D__VIGASOCO_SDL_STATIC__ -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
 VPATH=.:../core:../core/abadia:../core/util:../core/systems
 
 OBJECTS = SDLAudioPlugin.o NULLAudioPlugin.o PluginMain.o
 
 ../VigasocoSDL/audio/libVigasocoSDLAudioPlugin.a: $(OBJECTS)
+	mkdir -p $(dir $@)
 	$(AR) cru $@ $(OBJECTS)
 
 # para comprobar que no le faltan dependencias por resolver a la libreria
 test: test.o
-	$(CXX) -g test.o -o test -l../VigasocoSDL/audio/libVigasocoSDLAudioPlugin.a `sdl-config --libs`
+	$(CXX) -g test.o -o test -l../VigasocoSDL/audio/libVigasocoSDLAudioPlugin.a `sdl2-config --libs`
 
 clean:
 	rm -f $(OBJECTS) ../VigasocoSDL/audio/libVigasocoSDLAudioPlugin.a test test.o

--- a/SDLAudioPlugin/SDLAudioPlugin.cpp
+++ b/SDLAudioPlugin/SDLAudioPlugin.cpp
@@ -15,6 +15,8 @@
 
 SDLAudioPlugin::SDLAudioPlugin()
 {
+	mute = false;
+	_isInitialized = false;
 }
 
 SDLAudioPlugin::~SDLAudioPlugin()
@@ -218,6 +220,11 @@ void SDLAudioPlugin::process(int *inputs)
 
 void SDLAudioPlugin::mix(UINT8 *stream,int len)
 {
+	// en SDL 1.2 el buffer llegaba inicializado a silencio; en SDL2 llega
+	// con el contenido del callback anterior, asi que si no se limpia aqui
+	// las mezclas se acumulan hasta saturar y el audio degenera en ruido
+	SDL_memset(stream, fmt_real.silence, len);
+
 	UINT32 amount;
 	for (tIteratorSounds it=sounds.begin();it!=sounds.end();it++)
 	{

--- a/SDLInputKeyboardPlugin/Makefile
+++ b/SDLInputKeyboardPlugin/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-O3 -fPIC -I../core -I../VigasocoSDL/ `sdl-config --cflags`
+CXXFLAGS=-O3 -fPIC -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
 VPATH=.:../core:../core/abadia:../core/util:../core/systems
 
 all: ../VigasocoSDL/input/libVigasocoSDLInputPlugin.so 

--- a/SDLInputKeyboardPlugin/Makefile.static
+++ b/SDLInputKeyboardPlugin/Makefile.static
@@ -1,4 +1,4 @@
-CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -fPIC -I../core -I../VigasocoSDL/ `sdl-config --cflags`
+CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -fPIC -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
 VPATH=.:../core:../core/abadia:../core/util:../core/systems:
 
 all: ../VigasocoSDL/input/libVigasocoSDLInputPlugin.a
@@ -6,6 +6,7 @@ all: ../VigasocoSDL/input/libVigasocoSDLInputPlugin.a
 OBJECTS = SDLInputKeyboardPlugin.o PluginMain.o
 
 ../VigasocoSDL/input/libVigasocoSDLInputPlugin.a: $(OBJECTS)
+	mkdir -p $(dir $@)
 	$(AR) cru $@ $(OBJECTS)
 
 clean:

--- a/SDLInputKeyboardPlugin/SDLInputKeyboardPlugin.cpp
+++ b/SDLInputKeyboardPlugin/SDLInputKeyboardPlugin.cpp
@@ -7,7 +7,18 @@
 
 #include <vector>
 
-SDLKey SDLInputKeyboardPlugin::g_keyMapping[END_OF_INPUTS];
+SDL_Scancode SDLInputKeyboardPlugin::g_keyMapping[END_OF_INPUTS];
+
+// en SDL2 el grab es por ventana; se usa la que tiene el foco de teclado
+static void SDLInputKeyboardPlugin_setGrab(SDL_bool grab)
+{
+	SDL_Window *window = SDL_GetKeyboardFocus();
+	if (window == NULL)
+		window = SDL_GetWindowFromID(1);
+
+	if (window != NULL)
+		SDL_SetWindowGrab(window, grab);
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // initialization and cleanup
@@ -73,17 +84,17 @@ void SDLInputKeyboardPlugin::end()
 		}
 	}
 #endif
-	SDL_WM_GrabInput(SDL_GRAB_OFF);
+	SDLInputKeyboardPlugin_setGrab(SDL_FALSE);
 }
 
 void SDLInputKeyboardPlugin::acquire()
 {
-	SDL_WM_GrabInput(SDL_GRAB_ON);
+	SDLInputKeyboardPlugin_setGrab(SDL_TRUE);
 }
 
 void SDLInputKeyboardPlugin::unAcquire()
 {
-	SDL_WM_GrabInput(SDL_GRAB_OFF);
+	SDLInputKeyboardPlugin_setGrab(SDL_FALSE);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -159,13 +170,8 @@ enum ps3_sixaxis_sdl_axis
 
 void SDLInputKeyboardPlugin::process(int *inputs)
 {
-	//Uint8 *keystate = SDL_GetKeyState(NULL);
 	int size;
-#ifndef __EMSCRIPTEN__
-	Uint8 *keystate_tmp=SDL_GetKeyState(&size);
-#else
-	Uint8 *keystate_tmp=SDL_GetKeyboardState(&size);
-#endif
+	const Uint8 *keystate_tmp=SDL_GetKeyboardState(&size);
 	std::vector<Uint8> keystate(keystate_tmp,keystate_tmp+size);
 
 #if defined _EE || defined _PS3
@@ -268,83 +274,83 @@ void SDLInputKeyboardPlugin::initRemapTable()
 
 	// game driver inputs
 
-	g_keyMapping[P1_UP] = SDLK_UP;
-	g_keyMapping[P1_LEFT] = SDLK_LEFT;
-	g_keyMapping[P1_DOWN] = SDLK_DOWN;
-	g_keyMapping[P1_RIGHT] = SDLK_RIGHT;
+	g_keyMapping[P1_UP] = SDL_SCANCODE_UP;
+	g_keyMapping[P1_LEFT] = SDL_SCANCODE_LEFT;
+	g_keyMapping[P1_DOWN] = SDL_SCANCODE_DOWN;
+	g_keyMapping[P1_RIGHT] = SDL_SCANCODE_RIGHT;
 
-	g_keyMapping[P1_BUTTON1] = SDLK_LCTRL;
-	g_keyMapping[P1_BUTTON1] = SDLK_SPACE;
-	g_keyMapping[P1_BUTTON2] = SDLK_LSUPER;
+	g_keyMapping[P1_BUTTON1] = SDL_SCANCODE_LCTRL;
+	g_keyMapping[P1_BUTTON1] = SDL_SCANCODE_SPACE;
+	g_keyMapping[P1_BUTTON2] = SDL_SCANCODE_LGUI;
 
-	g_keyMapping[P2_UP] = SDLK_w;
-	g_keyMapping[P2_LEFT] = SDLK_a; 
-	g_keyMapping[P2_DOWN] = SDLK_s;
-	g_keyMapping[P2_RIGHT] = SDLK_d;
-	g_keyMapping[P2_BUTTON1] = SDLK_y;
-	g_keyMapping[P2_BUTTON2] = SDLK_u;
+	g_keyMapping[P2_UP] = SDL_SCANCODE_W;
+	g_keyMapping[P2_LEFT] = SDL_SCANCODE_A;
+	g_keyMapping[P2_DOWN] = SDL_SCANCODE_S;
+	g_keyMapping[P2_RIGHT] = SDL_SCANCODE_D;
+	g_keyMapping[P2_BUTTON1] = SDL_SCANCODE_Y;
+	g_keyMapping[P2_BUTTON2] = SDL_SCANCODE_U;
 
-	g_keyMapping[START_1] = SDLK_1;
-	g_keyMapping[START_2] = SDLK_2;
-	g_keyMapping[COIN_1] = SDLK_5;
-	g_keyMapping[COIN_2] = SDLK_6;
-	g_keyMapping[SERVICE_1] = SDLK_9;
-	g_keyMapping[SERVICE_2] = SDLK_0;
+	g_keyMapping[START_1] = SDL_SCANCODE_1;
+	g_keyMapping[START_2] = SDL_SCANCODE_2;
+	g_keyMapping[COIN_1] = SDL_SCANCODE_5;
+	g_keyMapping[COIN_2] = SDL_SCANCODE_6;
+	g_keyMapping[SERVICE_1] = SDL_SCANCODE_9;
+	g_keyMapping[SERVICE_2] = SDL_SCANCODE_0;
 
 	// keyboard inputs
-	g_keyMapping[KEYBOARD_A] = SDLK_a;
-	g_keyMapping[KEYBOARD_B] = SDLK_b;
-	g_keyMapping[KEYBOARD_C] = SDLK_c;
-	g_keyMapping[KEYBOARD_D] = SDLK_d;
-	g_keyMapping[KEYBOARD_E] = SDLK_e;
-	g_keyMapping[KEYBOARD_F] = SDLK_f;
-	g_keyMapping[KEYBOARD_G] = SDLK_g;
-	g_keyMapping[KEYBOARD_H] = SDLK_h;
-	g_keyMapping[KEYBOARD_I] = SDLK_i;
-	g_keyMapping[KEYBOARD_J] = SDLK_j;
-	g_keyMapping[KEYBOARD_K] = SDLK_k;
-	g_keyMapping[KEYBOARD_L] = SDLK_l;
-	g_keyMapping[KEYBOARD_M] = SDLK_m;
-	g_keyMapping[KEYBOARD_N] = SDLK_n;
-	g_keyMapping[KEYBOARD_O] = SDLK_o;
-	g_keyMapping[KEYBOARD_P] = SDLK_p;
-	g_keyMapping[KEYBOARD_Q] = SDLK_q;
-	g_keyMapping[KEYBOARD_R] = SDLK_r;
-	g_keyMapping[KEYBOARD_S] = SDLK_s;
-	g_keyMapping[KEYBOARD_T] = SDLK_t;
-	g_keyMapping[KEYBOARD_U] = SDLK_u;
-	g_keyMapping[KEYBOARD_V] = SDLK_v;
-	g_keyMapping[KEYBOARD_W] = SDLK_w;
-	g_keyMapping[KEYBOARD_X] = SDLK_x;
-	g_keyMapping[KEYBOARD_Y] = SDLK_y;
-	g_keyMapping[KEYBOARD_Z] = SDLK_z;
-	g_keyMapping[KEYBOARD_0] = SDLK_0;
-	g_keyMapping[KEYBOARD_1] = SDLK_1;
-	g_keyMapping[KEYBOARD_2] = SDLK_2;
-	g_keyMapping[KEYBOARD_3] = SDLK_3;
-	g_keyMapping[KEYBOARD_4] = SDLK_4;
-	g_keyMapping[KEYBOARD_5] = SDLK_5;
-	g_keyMapping[KEYBOARD_6] = SDLK_6;
-	g_keyMapping[KEYBOARD_7] = SDLK_7;
-	g_keyMapping[KEYBOARD_8] = SDLK_8;
-	g_keyMapping[KEYBOARD_9] = SDLK_9; 
-	g_keyMapping[KEYBOARD_SPACE] = SDLK_SPACE;
-	g_keyMapping[KEYBOARD_INTRO] = SDLK_RETURN; // SDLK_KP_ENTER;
-	g_keyMapping[KEYBOARD_SUPR] = SDLK_DELETE;
+	g_keyMapping[KEYBOARD_A] = SDL_SCANCODE_A;
+	g_keyMapping[KEYBOARD_B] = SDL_SCANCODE_B;
+	g_keyMapping[KEYBOARD_C] = SDL_SCANCODE_C;
+	g_keyMapping[KEYBOARD_D] = SDL_SCANCODE_D;
+	g_keyMapping[KEYBOARD_E] = SDL_SCANCODE_E;
+	g_keyMapping[KEYBOARD_F] = SDL_SCANCODE_F;
+	g_keyMapping[KEYBOARD_G] = SDL_SCANCODE_G;
+	g_keyMapping[KEYBOARD_H] = SDL_SCANCODE_H;
+	g_keyMapping[KEYBOARD_I] = SDL_SCANCODE_I;
+	g_keyMapping[KEYBOARD_J] = SDL_SCANCODE_J;
+	g_keyMapping[KEYBOARD_K] = SDL_SCANCODE_K;
+	g_keyMapping[KEYBOARD_L] = SDL_SCANCODE_L;
+	g_keyMapping[KEYBOARD_M] = SDL_SCANCODE_M;
+	g_keyMapping[KEYBOARD_N] = SDL_SCANCODE_N;
+	g_keyMapping[KEYBOARD_O] = SDL_SCANCODE_O;
+	g_keyMapping[KEYBOARD_P] = SDL_SCANCODE_P;
+	g_keyMapping[KEYBOARD_Q] = SDL_SCANCODE_Q;
+	g_keyMapping[KEYBOARD_R] = SDL_SCANCODE_R;
+	g_keyMapping[KEYBOARD_S] = SDL_SCANCODE_S;
+	g_keyMapping[KEYBOARD_T] = SDL_SCANCODE_T;
+	g_keyMapping[KEYBOARD_U] = SDL_SCANCODE_U;
+	g_keyMapping[KEYBOARD_V] = SDL_SCANCODE_V;
+	g_keyMapping[KEYBOARD_W] = SDL_SCANCODE_W;
+	g_keyMapping[KEYBOARD_X] = SDL_SCANCODE_X;
+	g_keyMapping[KEYBOARD_Y] = SDL_SCANCODE_Y;
+	g_keyMapping[KEYBOARD_Z] = SDL_SCANCODE_Z;
+	g_keyMapping[KEYBOARD_0] = SDL_SCANCODE_0;
+	g_keyMapping[KEYBOARD_1] = SDL_SCANCODE_1;
+	g_keyMapping[KEYBOARD_2] = SDL_SCANCODE_2;
+	g_keyMapping[KEYBOARD_3] = SDL_SCANCODE_3;
+	g_keyMapping[KEYBOARD_4] = SDL_SCANCODE_4;
+	g_keyMapping[KEYBOARD_5] = SDL_SCANCODE_5;
+	g_keyMapping[KEYBOARD_6] = SDL_SCANCODE_6;
+	g_keyMapping[KEYBOARD_7] = SDL_SCANCODE_7;
+	g_keyMapping[KEYBOARD_8] = SDL_SCANCODE_8;
+	g_keyMapping[KEYBOARD_9] = SDL_SCANCODE_9;
+	g_keyMapping[KEYBOARD_SPACE] = SDL_SCANCODE_SPACE;
+	g_keyMapping[KEYBOARD_INTRO] = SDL_SCANCODE_RETURN; // SDL_SCANCODE_KP_ENTER;
+	g_keyMapping[KEYBOARD_SUPR] = SDL_SCANCODE_DELETE;
 
 	// core inputs
-	g_keyMapping[FUNCTION_1] = SDLK_F1;
-	g_keyMapping[FUNCTION_2] = SDLK_F2;
-	g_keyMapping[FUNCTION_3] = SDLK_F3;
-	g_keyMapping[FUNCTION_4] = SDLK_F4;
-	g_keyMapping[FUNCTION_5] = SDLK_F5;
-	g_keyMapping[FUNCTION_6] = SDLK_F6;
-	g_keyMapping[FUNCTION_7] = SDLK_F7;
-	g_keyMapping[FUNCTION_8] = SDLK_F8;
-	g_keyMapping[FUNCTION_9] = SDLK_F9;
-	g_keyMapping[FUNCTION_10] = SDLK_F10;
-	g_keyMapping[FUNCTION_11] = SDLK_F11;
-	g_keyMapping[FUNCTION_12] = SDLK_F12;
+	g_keyMapping[FUNCTION_1] = SDL_SCANCODE_F1;
+	g_keyMapping[FUNCTION_2] = SDL_SCANCODE_F2;
+	g_keyMapping[FUNCTION_3] = SDL_SCANCODE_F3;
+	g_keyMapping[FUNCTION_4] = SDL_SCANCODE_F4;
+	g_keyMapping[FUNCTION_5] = SDL_SCANCODE_F5;
+	g_keyMapping[FUNCTION_6] = SDL_SCANCODE_F6;
+	g_keyMapping[FUNCTION_7] = SDL_SCANCODE_F7;
+	g_keyMapping[FUNCTION_8] = SDL_SCANCODE_F8;
+	g_keyMapping[FUNCTION_9] = SDL_SCANCODE_F9;
+	g_keyMapping[FUNCTION_10] = SDL_SCANCODE_F10;
+	g_keyMapping[FUNCTION_11] = SDL_SCANCODE_F11;
+	g_keyMapping[FUNCTION_12] = SDL_SCANCODE_F12;
 
 	// check that all inputs have been mapped (for safety)
 	for (int i = 0; i < END_OF_INPUTS; i++){
@@ -383,7 +389,7 @@ void SDLInputKeyboardPlugin::setProperty(std::string prop, int index, int data)
 {
 	if (prop == "keyConfig"){
 		if ((index >= 0) && (index < END_OF_INPUTS)){
-			g_keyMapping[index] = (SDLKey)data;
+			g_keyMapping[index] = (SDL_Scancode)data;
 		}
 	}
 }

--- a/SDLInputKeyboardPlugin/SDLInputKeyboardPlugin.h
+++ b/SDLInputKeyboardPlugin/SDLInputKeyboardPlugin.h
@@ -19,7 +19,7 @@ protected:
 
 	UINT8 _keys[256];							// keys state
 
-	static SDLKey g_keyMapping[END_OF_INPUTS];	// VIGASOCO input to DirectInput mapping
+	static SDL_Scancode g_keyMapping[END_OF_INPUTS];	// VIGASOCO input to SDL scancode mapping
 #if defined _EE || defined _PS3
 	SDL_Joystick *joy;
 #endif

--- a/SDLVideoPlugins/Makefile
+++ b/SDLVideoPlugins/Makefile
@@ -1,5 +1,5 @@
-CXXFLAGS=-O3 -fPIC -I../core -I../VigasocoSDL/ `sdl-config --cflags`
-#CXXFLAGS=-g -fPIC -I../core -I../VigasocoSDL/ `sdl-config --cflags`
+CXXFLAGS=-O3 -fPIC -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
+#CXXFLAGS=-g -fPIC -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
 VPATH=.:../core:../core/abadia:../core/util:../core/systems
 
 OBJECTS = SDLDrawPlugin.o SDLVideoPlugins.o SDLDrawPlugin8bpp.o SDLDrawPlugin24bpp.o SDLDrawPluginPaletaGrises8bpp.o PluginMain.o
@@ -10,7 +10,7 @@ OBJECTS = SDLDrawPlugin.o SDLVideoPlugins.o SDLDrawPlugin8bpp.o SDLDrawPlugin24b
 
 # para comprobar que no le faltan dependencias por resolver a la libreria
 test: test.o
-	$(CXX) -g test.o -o test -L ../VigasocoSDL/video/ -l VigasocoSDLDrawPlugin `sdl-config --libs`
+	$(CXX) -g test.o -o test -L ../VigasocoSDL/video/ -l VigasocoSDLDrawPlugin `sdl2-config --libs`
 
 clean:
 	rm -f $(OBJECTS) ../VigasocoSDL/video/libVigasocoSDLDrawPlugin.so test test.o

--- a/SDLVideoPlugins/Makefile.static
+++ b/SDLVideoPlugins/Makefile.static
@@ -1,15 +1,16 @@
-#CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl-config --cflags`
-CXXFLAGS=-D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl-config --cflags`
+#CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
+CXXFLAGS=-D__VIGASOCO_SDL_STATIC__ -O3 -I../core -I../VigasocoSDL/ `sdl2-config --cflags`
 VPATH=.:../core:../core/abadia:../core/util:../core/systems
 
 OBJECTS = SDLDrawPlugin.o SDLVideoPlugins.o SDLDrawPlugin8bpp.o SDLDrawPlugin24bpp.o SDLDrawPluginPaletaGrises8bpp.o PluginMain.o
 
 ../VigasocoSDL/video/libVigasocoSDLDrawPlugin.a: $(OBJECTS)
+	mkdir -p $(dir $@)
 	$(AR) cru $@ $(OBJECTS)
 
 # para comprobar que no le faltan dependencias por resolver a la libreria
 test: test.o
-	$(CXX) -g test.o -o test -l../VigasocoSDL/video/libVigasocoSDLDrawPlugin.a `sdl-config --libs`
+	$(CXX) -g test.o -o test -l../VigasocoSDL/video/libVigasocoSDLDrawPlugin.a `sdl2-config --libs`
 
 clean:
 	rm -f $(OBJECTS) ../VigasocoSDL/video/libVigasocoSDLDrawPlugin.a test test.o

--- a/SDLVideoPlugins/SDLBasicDrawPlugin.h
+++ b/SDLVideoPlugins/SDLBasicDrawPlugin.h
@@ -20,12 +20,16 @@ template<typename T>
 class SDLBasicDrawPlugin : public SDLDrawPlugin
 {
 protected:
-	SDL_Rect *SDLRects;
-	bool **updated_rect;
-	int xrects,yrects;
+	SDL_Window *window;
+	SDL_Renderer *renderer;
+	SDL_Texture *texture;
 
-        SDL_Surface *screen;
-	
+	// superficie donde dibuja el juego, con el bpp del plugin
+	// (para 8bpp mantiene la paleta indexada como en SDL 1.2)
+	SDL_Surface *screen;
+	// copia en ARGB8888 que se sube a la textura en cada render
+	SDL_Surface *rgbaScreen;
+
 	bool _isInitialized;
 	UINT32 _flags;
 	int _bpp;
@@ -33,7 +37,7 @@ protected:
 private:
 	IPalette *_originalPalette;
 public:
-	SDLBasicDrawPlugin(){ screen = NULL; _isInitialized=false; _flags = DEFAULT::flags; _bpp = DEFAULT::bpp ; _palette = NULL; _originalPalette=NULL; }
+	SDLBasicDrawPlugin(){ window = NULL; renderer = NULL; texture = NULL; screen = NULL; rgbaScreen = NULL; _isInitialized=false; _flags = DEFAULT::flags; _bpp = DEFAULT::bpp ; _palette = NULL; _originalPalette=NULL; }
 	virtual ~SDLBasicDrawPlugin(){ }
 	virtual bool init(const VideoInfo *vi, IPalette *pal);
 	virtual void end(void);
@@ -80,9 +84,12 @@ public:
 	 virtual const int *getPropertiesType() const {};
 	 virtual void setProperty(std::string prop, int data) {
 		std::string ToggleFullScreen("ToggleFullScreen");
-		if ( prop == ToggleFullScreen )
+		if ( prop == ToggleFullScreen && window )
 		{
-			SDL_WM_ToggleFullScreen(screen);
+			Uint32 fullscreen = SDL_GetWindowFlags(window) &
+				(SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP);
+			SDL_SetWindowFullscreen(window,
+				fullscreen ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
 		}
 	};
 	 virtual void setProperty(std::string prop, int index, int data) {};

--- a/SDLVideoPlugins/SDLBasicDrawPluginTemplates.cpp
+++ b/SDLVideoPlugins/SDLBasicDrawPluginTemplates.cpp
@@ -5,10 +5,6 @@
 #include "SDLBasicDrawPlugin.h"
 #include "IPalette.h"
 
-// 6 para cuadricula de 64*64 pixeles (2^6)
-// 7 para cuadricula de 128*128 pixeles (2^7)
-#define FACTOR_REJILLA 6
-
 template<typename T>
 bool SDLBasicDrawPlugin<T>::init(const VideoInfo *vi, IPalette *pal)
 {
@@ -18,15 +14,45 @@ bool SDLBasicDrawPlugin<T>::init(const VideoInfo *vi, IPalette *pal)
 		return false;
 	}
 
-	screen = SDL_SetVideoMode(vi->width, vi->height, _bpp, _flags);
-//	screen = SDL_SetVideoMode(640, 480, 8, SDL_SWSURFACE|SDL_ANYFORMAT);
+	window = SDL_CreateWindow("VigasocoSDL",
+			SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+			vi->width, vi->height, _flags);
+	if ( window == NULL ) {
+		fprintf(stderr, "Couldn't create %dx%d window: %s\n",
+				vi->width,vi->height,SDL_GetError());
+		return false;
+	}
+
+	renderer = SDL_CreateRenderer(window, -1, 0);
+	if ( renderer == NULL ) {
+		fprintf(stderr, "Couldn't create renderer: %s\n", SDL_GetError());
+		return false;
+	}
+
+	// escalado con relacion de aspecto correcta en fullscreen/resize
+	SDL_RenderSetLogicalSize(renderer, vi->width, vi->height);
+
+	texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
+			SDL_TEXTUREACCESS_STREAMING, vi->width, vi->height);
+	if ( texture == NULL ) {
+		fprintf(stderr, "Couldn't create texture: %s\n", SDL_GetError());
+		return false;
+	}
+
+	screen = SDL_CreateRGBSurface(0, vi->width, vi->height, _bpp, 0, 0, 0, 0);
 	if ( screen == NULL ) {
-		fprintf(stderr, "Couldn't set %dx%dx%d video mode: %s\n",
+		fprintf(stderr, "Couldn't create %dx%dx%d surface: %s\n",
 				vi->width,vi->height,_bpp,SDL_GetError());
 		return false;
 	}
-//	printf("set %dx%dx%d video mode(%s): %s\n",
-//				vi->width,vi->height,_bpp,screen->flags & SDL_DOUBLEBUF?"DOUBLEBUFF":"No double buffer",SDL_GetError());
+
+	rgbaScreen = SDL_CreateRGBSurfaceWithFormat(0, vi->width, vi->height,
+			32, SDL_PIXELFORMAT_ARGB8888);
+	if ( rgbaScreen == NULL ) {
+		fprintf(stderr, "Couldn't create conversion surface: %s\n",
+				SDL_GetError());
+		return false;
+	}
 
 	_originalPalette=pal;
 
@@ -34,37 +60,42 @@ bool SDLBasicDrawPlugin<T>::init(const VideoInfo *vi, IPalette *pal)
 	pal->attach(this);
 	updateFullPalette(pal);
 
-#ifndef _EE
-	xrects=(vi->width>>FACTOR_REJILLA);
-	yrects=(vi->height>>FACTOR_REJILLA);
-	int nrects=xrects*yrects;
-
-	updated_rect = new bool*[xrects];
-	for (int i=0;i<xrects;i++)
-	{
-		updated_rect[i]=new bool[yrects];
-	}  
-	for(int i=0;i<xrects;i++)
-	{
-		for(int j=0;j<yrects;j++)
-		{
-			updated_rect[i][j]=false;
-		}
-	}
-
-	SDLRects = new SDL_Rect[nrects];
-#endif
-
 	_isInitialized = true;
-	
+
 	return _isInitialized;
 };
 
 
 template<typename T>
-void SDLBasicDrawPlugin<T>::end()  { 
+void SDLBasicDrawPlugin<T>::end()  {
 	if ( _originalPalette )
 		_originalPalette->detach(this);
+
+    if ( rgbaScreen ) {
+        SDL_FreeSurface(rgbaScreen);
+        rgbaScreen = NULL;
+    }
+
+	if ( screen ) {
+        SDL_FreeSurface(screen);
+        screen = NULL;
+    }
+
+	if ( texture ) {
+        SDL_DestroyTexture(texture);
+        texture = NULL;
+    }
+
+	if ( renderer ) {
+        SDL_DestroyRenderer(renderer);
+        renderer = NULL;
+    }
+
+	if ( window ) {
+        SDL_DestroyWindow(window);
+        window = NULL;
+    }
+
 	_isInitialized = false;
 };
 
@@ -102,47 +133,21 @@ void SDLBasicDrawPlugin<T>::update(IPalette *palette, int data)
 template<typename T>
 inline void SDLBasicDrawPlugin<T>::updateRect(int x,int y)
 {
-//	fprintf(stderr,"%d %d -> rect %d,%d\n",x,y,x>>FACTOR_REJILLA,y>>FACTOR_REJILLA);
-
-#ifndef _EE
-	updated_rect[x>>FACTOR_REJILLA][y>>FACTOR_REJILLA]=true;
-#endif
+	// con SDL2 se sube la textura completa y se presenta en cada render,
+	// por lo que ya no hace falta llevar la cuenta de zonas modificadas
 }
 
 // drawing methods
 template<typename T>
 void SDLBasicDrawPlugin<T>::render(bool throttle)
 {
-#ifdef _EE
-	SDL_UpdateRects(screen,0,NULL);
-#else
-
-	int n=0;
-	for(int i=0;i<xrects;i++)
-	{
-		for(int j=0;j<yrects;j++)
-		{
-			if (updated_rect[i][j])
-			{
-				SDLRects[n].x=i<<FACTOR_REJILLA;
-				SDLRects[n].y=j<<FACTOR_REJILLA;
-				SDLRects[n].w=1<<FACTOR_REJILLA;
-				SDLRects[n++].h=1<<FACTOR_REJILLA;
-			}
-		}
-	}
-	if(n)
-	{
-		SDL_UpdateRects(screen,n,SDLRects);
-                for(int i=0;i<xrects;i++)
-                {
-                        for(int j=0;j<yrects;j++)
-                        {
-                                updated_rect[i][j]=false;
-                        }
-                }
-	}
-#endif
+	// el juego dibuja en la superficie con paleta; se convierte a
+	// ARGB8888, se sube a la textura y se presenta
+	SDL_BlitSurface(screen, NULL, rgbaScreen, NULL);
+	SDL_UpdateTexture(texture, NULL, rgbaScreen->pixels, rgbaScreen->pitch);
+	SDL_RenderClear(renderer);
+	SDL_RenderCopy(renderer, texture, NULL, NULL);
+	SDL_RenderPresent(renderer);
 };
 
 template<typename T>

--- a/SDLVideoPlugins/SDLDrawPlugin8bpp.cpp
+++ b/SDLVideoPlugins/SDLDrawPlugin8bpp.cpp
@@ -10,7 +10,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 void SDLDrawPlugin8bpp::updateFullPalette(IPalette *palette)
-{ 
+{
 	SDL_Color colors[256];
 
 	for (int i = 0; i < palette->getTotalColors(); i++){
@@ -20,14 +20,15 @@ void SDLDrawPlugin8bpp::updateFullPalette(IPalette *palette)
 		colors[i].r=r;
 		colors[i].g=g;
 		colors[i].b=b;
+		colors[i].a=255;
 	}
-	SDL_mutexP(cs);
-	SDL_SetColors(screen, colors, 0, 256); 
-	SDL_mutexV(cs);
+	SDL_LockMutex(cs);
+	SDL_SetPaletteColors(screen->format->palette, colors, 0, palette->getTotalColors());
+	SDL_UnlockMutex(cs);
 }
 
 void SDLDrawPlugin8bpp::update(IPalette *palette, int data)
-{ 
+{
 	if (data != -1){
 		// single color update
 		UINT8 r, g, b;
@@ -37,20 +38,21 @@ void SDLDrawPlugin8bpp::update(IPalette *palette, int data)
 		color.r=r;
 		color.g=g;
 		color.b=b;
+		color.a=255;
 
-		SDL_mutexP(cs);
-		SDL_SetColors(screen, &color, data, 1);
-		SDL_mutexV(cs);
+		SDL_LockMutex(cs);
+		SDL_SetPaletteColors(screen->format->palette, &color, data, 1);
+		SDL_UnlockMutex(cs);
 	} else {
 		// full palette update
 		updateFullPalette(palette);
-	} 
+	}
 }
 void SDLDrawPlugin8bpp::render(bool throttle)
 {
-	SDL_mutexP(cs);
+	SDL_LockMutex(cs);
 	SDLBasicDrawPlugin<UINT8>::render(throttle);
-	SDL_mutexV(cs);
+	SDL_UnlockMutex(cs);
 }
 
 

--- a/SDLVideoPlugins/SDLDrawPluginPaletaGrises8bpp.cpp
+++ b/SDLVideoPlugins/SDLDrawPluginPaletaGrises8bpp.cpp
@@ -19,9 +19,10 @@ bool SDLDrawPluginPaletaGrises8bpp::init(const VideoInfo *vi, IPalette *pal)
 			colors[i].r=i;
 			colors[i].g=i;
 			colors[i].b=i;
-			} 
+			colors[i].a=255;
+			}
 
-		SDL_SetColors(screen, colors, 0, 256); 
+		SDL_SetPaletteColors(screen->format->palette, colors, 0, 256);
 
 		pal->attach(this);
 		updateFullPalette(pal);

--- a/SDLVideoPlugins/SDLVideoPlugins.h
+++ b/SDLVideoPlugins/SDLVideoPlugins.h
@@ -58,7 +58,7 @@ template <class T>
 class SDLDrawPluginFullScreen: public T
 {
 	public:
-		SDLDrawPluginFullScreen() { T::_flags|=SDL_FULLSCREEN; }
+		SDLDrawPluginFullScreen() { T::_flags|=SDL_WINDOW_FULLSCREEN_DESKTOP; }
 };
 
 typedef SDLDrawPluginFullScreen<SDLDrawPlugin8bpp> SDLDrawPluginFullScreen8bpp;

--- a/VigasocoSDL/Makefile
+++ b/VigasocoSDL/Makefile
@@ -1,5 +1,5 @@
-#CXXFLAGS=-O3 -I../core `sdl-config --cflags` 
-CXXFLAGS=-g -I../core `sdl-config --cflags` 
+#CXXFLAGS=-O3 -I../core `sdl2-config --cflags` 
+CXXFLAGS=-g -I../core `sdl2-config --cflags` 
 VPATH=.:../core:../core/abadia:../core/util:../core/systems
 
 # en OBJECTS_CORE falta Operations.o ??
@@ -12,7 +12,7 @@ OBJECTS_SDL = PluginHandler.o SDLTimer.o SDLCriticalSection.o SDLPalette.o SDLTh
 OBJECTS = $(OBJECTS_CORE) $(OBJECTS_ABADIA) $(OBJECTS_SDL) 
 
 VigasocoSDL: $(OBJECTS)
-	$(CXX) -g $(OBJECTS) `sdl-config --libs` -o VigasocoSDL
+	$(CXX) -g $(OBJECTS) `sdl2-config --libs` -o VigasocoSDL
 	#strip VigasocoSDL
 
 clean:

--- a/VigasocoSDL/Makefile.static
+++ b/VigasocoSDL/Makefile.static
@@ -1,5 +1,5 @@
-#CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -I../core `sdl-config --cflags` 
-CXXFLAGS=-D__VIGASOCO_SDL_STATIC__ -O3 -I../core `sdl-config --cflags` 
+#CXXFLAGS=-g -D__VIGASOCO_SDL_STATIC__ -O3 -I../core `sdl2-config --cflags` 
+CXXFLAGS=-D__VIGASOCO_SDL_STATIC__ -O3 -I../core `sdl2-config --cflags` 
 VPATH=.:../core:../core/abadia:../core/util:../core/systems
 
 # en OBJECTS_CORE falta Operations.o ??
@@ -14,8 +14,10 @@ OBJECTS = $(OBJECTS_CORE) $(OBJECTS_ABADIA) $(OBJECTS_SDL)
 OBJECTS_STATIC_PLUGINS = video/libVigasocoSDLDrawPlugin.a input/libVigasocoSDLInputPlugin.a audio/libVigasocoSDLAudioPlugin.a
 
 VigasocoSDL: $(OBJECTS) $(OBJECTS_STATIC_PLUGINS)
-#	$(CXX) -g -static $(OBJECTS) $(OBJECTS_STATIC_PLUGINS) `sdl-config --static-libs` -ldl -o VigasocoSDL
-	$(CXX) -static $(OBJECTS) $(OBJECTS_STATIC_PLUGINS) `sdl-config --static-libs` -ldl -o VigasocoSDL
+# los plugins van enlazados estaticamente en el binario, pero SDL2 se enlaza
+# dinamicamente (el enlazado -static de SDL2 no es viable en Linux de escritorio)
+#	$(CXX) -g $(OBJECTS) $(OBJECTS_STATIC_PLUGINS) `sdl2-config --libs` -ldl -o VigasocoSDL
+	$(CXX) $(OBJECTS) $(OBJECTS_STATIC_PLUGINS) `sdl2-config --libs` -ldl -o VigasocoSDL
 	strip VigasocoSDL
 
 clean:

--- a/VigasocoSDL/SDLCriticalSection.cpp
+++ b/VigasocoSDL/SDLCriticalSection.cpp
@@ -32,10 +32,10 @@ void SDLCriticalSection::destroy()
 
 void SDLCriticalSection::enter()
 {
-	SDL_mutexP(cs);
+	SDL_LockMutex(cs);
 }
 
 void SDLCriticalSection::leave()
 {
-	SDL_mutexV(cs);
+	SDL_UnlockMutex(cs);
 }

--- a/VigasocoSDL/SDLThread.cpp
+++ b/VigasocoSDL/SDLThread.cpp
@@ -38,13 +38,9 @@ bool SDLThread::start()
 	}
 
 	// creates the thread
-#ifndef __EMSCRIPTEN_PTHREADS__ 
-	_handle = SDL_CreateThread((int (*)(void*))ThreadProc, this);
+#ifndef _VIGASOCO_SDL_THREAD_PTHREADS_
+	_handle = SDL_CreateThread((SDL_ThreadFunction)ThreadProc, "VigasocoGameLogic", this);
 #else
-	// SDL 1.2 en emscripten aún no hace uso de pthreads
-	// aunque emscripten ya tiene soporte pthreads
-	// cambiar si migramos a SDL2 o actulizan el 1.2 en emscripten
-	// Valorar si tener una clas POSIX_THREAD que implemente iThread
 	pthread_create(&_handle,NULL,(void *(*)(void *))ThreadProc,this);
 #endif
 
@@ -63,11 +59,15 @@ void SDLThread::end()
 	if (_handle != NULL){
 		_isRunning = false;
 
-		// kill the thread
-#ifndef __EMSCRIPTEN_PTHREADS__ 
-		SDL_KillThread(_handle);
+		// el hilo de lógica no tiene parada cooperativa: hay que matarlo
+		// antes de que se liberen los plugins que está usando
+#ifndef _VIGASOCO_SDL_THREAD_PTHREADS_
+		// SDL2 eliminó SDL_KillThread; sin pthreads solo se puede separar
+		// el hilo y dejar que el sistema operativo lo recoja al salir
+		SDL_DetachThread(_handle);
 #else
 		pthread_cancel(_handle);
+		pthread_join(_handle,NULL);
 #endif
 
 		_handle = NULL;

--- a/VigasocoSDL/SDLThread.h
+++ b/VigasocoSDL/SDLThread.h
@@ -12,7 +12,11 @@
 #include "SDL.h"
 #include "SDL_thread.h"
 
-#ifdef __EMSCRIPTEN_PTHREADS__ 
+// SDL2 eliminó SDL_KillThread, pero el hilo de lógica del juego no tiene
+// parada cooperativa, así que en sistemas POSIX se usan pthreads
+// directamente para poder cancelarlo al salir (como hacía SDL_KillThread)
+#if defined(__EMSCRIPTEN_PTHREADS__) || defined(__unix__) || defined(__APPLE__)
+#define _VIGASOCO_SDL_THREAD_PTHREADS_
 #include <pthread.h>
 #endif
 
@@ -20,7 +24,7 @@ class SDLThread : public IThread
 {
 // fields
 protected:
-#ifdef __EMSCRIPTEN_PTHREADS__ 
+#ifdef _VIGASOCO_SDL_THREAD_PTHREADS_
 	pthread_t _handle;
 #else
 	SDL_Thread *_handle;

--- a/VigasocoSDL/VigasocoSDL.cpp
+++ b/VigasocoSDL/VigasocoSDL.cpp
@@ -208,7 +208,15 @@ void VigasocoSDL::createAsyncThread()
 void VigasocoSDL::initCompleted()
 {
 	std::string titulo_ventana = "VigasocoSDL v0.096: " + _driver->getFullName();
-	SDL_WM_SetCaption(titulo_ventana.c_str(),titulo_ventana.c_str());
+	// en SDL2 el titulo es por ventana; la ventana la crea el plugin de video,
+	// asi que se localiza a traves del foco de teclado (o su id)
+	SDL_Window *window = SDL_GetKeyboardFocus();
+	if (window == NULL)
+		window = SDL_GetWindowFromID(1);
+
+	if (window != NULL)
+		SDL_SetWindowTitle(window, titulo_ventana.c_str());
+
 	SDL_ShowCursor(SDL_DISABLE);
 }
 


### PR DESCRIPTION
Este PR migra el port SDL de Vigasoco de SDL 1.2 a SDL2, manteniendo la misma arquitectura de plugins.

## Cambios

**Video** (`SDLVideoPlugins/`)

- `SDL_SetVideoMode`/`SDL_UpdateRects` se sustituyen por el modelo de SDL2: ventana + renderer + textura *streaming*. El juego sigue dibujando en una superficie con paleta indexada, que se convierte y presenta en cada frame.
- Fullscreen con `SDL_WINDOW_FULLSCREEN_DESKTOP` y escalado que conserva la relación de aspecto.

**Input** (`SDLInputKeyboardPlugin/`)

- En SDL2 el estado del teclado se indexa por *scancode*, así que la tabla de mapeo pasa de `SDLK_*` a `SDL_SCANCODE_*`.

**Threads** (`VigasocoSDL/`)

- SDL2 eliminó `SDL_KillThread`. En POSIX se usan pthreads con `pthread_cancel`/`pthread_join` para poder parar el hilo de lógica al salir.

**Audio** (`SDLAudioPlugin/`)

- SDL2 ya no inicializa a silencio el buffer del callback: hay que limpiarlo en `mix()` o las mezclas se acumulan hasta degenerar en ruido. Se inicializan además `mute` y `_isInitialized`.

**Makefiles**

- `sdl-config` → `sdl2-config`, creación de los directorios de salida de los plugins, y el binario estático enlaza SDL2 dinámico.
- Las invocaciones recursivas usan `$(MAKE)` en lugar de `make`, para propagar las opciones (como `-j`) a los subdirectorios.

## Fuera de alcance

Las variantes PS2/PS3/PNaCl/emscripten y `SDLVideoPlugins.DOUBLE-BUFFER` se quedan en SDL 1.2.
